### PR TITLE
Fix Level 15 & Level 16

### DIFF
--- a/Level 15/Dockerfile
+++ b/Level 15/Dockerfile
@@ -27,6 +27,10 @@ RUN chown -R www-data:www-data /var/www/html
 # 设置shell的工作目录
 WORKDIR /var/www/html
 
+# 根据题目提前创建沙盒目录并授权
+RUN mkdir -p /www/sandbox
+RUN chown -R www-data:www-data /www
+
 # [可选]指定对外暴露端口，对于GZCTF等平台，强制EXPOSE可能会造成非预期端口泄露，请酌情启用
 # EXPOSE 80
 

--- a/Level 16/Dockerfile
+++ b/Level 16/Dockerfile
@@ -27,6 +27,10 @@ RUN chown -R www-data:www-data /var/www/html
 # 设置shell的工作目录
 WORKDIR /var/www/html
 
+# 根据题目提前创建沙盒目录并授权
+RUN mkdir -p /www/sandbox
+RUN chown -R www-data:www-data /www
+
 # [可选]指定对外暴露端口，对于GZCTF等平台，强制EXPOSE可能会造成非预期端口泄露，请酌情启用
 # EXPOSE 80
 


### PR DESCRIPTION
源码中有如下代码
```
$sandbox = '/www/sandbox/' . md5("orange" . $_SERVER['REMOTE_ADDR']);
@mkdir($sandbox);
@chdir($sandbox);
```
但是我发现 www-data 并没有创建相关目录的权限
所以改了一下