### PR TITLE
Fix duplicate highlight_file call in index.php

### DIFF
--- a/Level 14/index.php
+++ b/Level 14/index.php
@@ -11,6 +11,7 @@
 
 
 */
+highlight_file(__FILE__);
 
 if(isset($_GET[1]) && strlen($_GET[1]) < 8){
     echo strlen($_GET[1]);
@@ -20,7 +21,7 @@ if(isset($_GET[1]) && strlen($_GET[1]) < 8){
     exit('too long');
 }
 
-highlight_file(__FILE__);
+
 
 
 ?>


### PR DESCRIPTION
修改highlight_file的位置,避免不传入参数时直接显示toolong,导致无法查看源代码